### PR TITLE
Fixed #3

### DIFF
--- a/SFlua/037-r1/init.lua
+++ b/SFlua/037-r1/init.lua
@@ -726,7 +726,7 @@ end
 
 function sampAddChatMessage(text, color)
     assert(isSampAvailable(), 'SA-MP is not available.')
-    sampAddChatMessageEx(CHAT_TYPE_DEBUG, text, '', color, -1)
+    sampAddChatMessageEx(CHAT_TYPE_DEBUG, text, '', color or -1, -1)
 end
 
 function sampGetChatDisplayMode()

--- a/SFlua/037-r1/init.lua
+++ b/SFlua/037-r1/init.lua
@@ -1484,7 +1484,7 @@ function sampAddChatMessageEx(_type, text, prefix, textColor, prefixColor)
     assert(isSampAvailable(), 'SA-MP is not available.')
     local char = ffi.cast('PCSTR', tostring(text))
     local charPrefix = prefix and ffi.cast('PCSTR', tostring(prefix))
-    samp_C.addMessage(samp_C.chat, _type, char, charPrefix, textColor or -1, prefixColor)
+    samp_C.addMessage(samp_C.chat, _type, char, charPrefix, tonumber(textColor) or -1, tonumber(prefixColor) or -1)
 end
 
 -- stPickupPool

--- a/SFlua/037-r1/init.lua
+++ b/SFlua/037-r1/init.lua
@@ -726,7 +726,7 @@ end
 
 function sampAddChatMessage(text, color)
     assert(isSampAvailable(), 'SA-MP is not available.')
-    sampAddChatMessageEx(CHAT_TYPE_DEBUG, text, '', color or -1, -1)
+    sampAddChatMessageEx(CHAT_TYPE_DEBUG, text, '', color, -1)
 end
 
 function sampGetChatDisplayMode()
@@ -1484,7 +1484,7 @@ function sampAddChatMessageEx(_type, text, prefix, textColor, prefixColor)
     assert(isSampAvailable(), 'SA-MP is not available.')
     local char = ffi.cast('PCSTR', tostring(text))
     local charPrefix = prefix and ffi.cast('PCSTR', tostring(prefix))
-    samp_C.addMessage(samp_C.chat, _type, char, charPrefix, textColor, prefixColor)
+    samp_C.addMessage(samp_C.chat, _type, char, charPrefix, textColor or -1, prefixColor)
 end
 
 -- stPickupPool


### PR DESCRIPTION
Fixed bug, that if no color argument provided, script crashes. [#3]
What is more, default color is 0xFFFFFF, whereas it unreadable 0x000000 in the original SAMPFUNCS